### PR TITLE
poupup messages (#875)

### DIFF
--- a/src/common/bsod.cpp
+++ b/src/common/bsod.cpp
@@ -146,7 +146,7 @@ static void stop_common(void) {
 //! @param term input message
 //! @param background_color background color
 static void print_error(term_t *term, color_t background_color) {
-    render_term(Rect16(10, 10, 220, 288), term, resource_font(IDR_FNT_NORMAL), background_color, COLOR_WHITE);
+    render_term(term, 10, 10, resource_font(IDR_FNT_NORMAL), background_color, COLOR_WHITE);
     display::DrawText(Rect16(10, 290, 220, 20), string_view_utf8::MakeCPUFLASH((const uint8_t *)project_version_full), resource_font(IDR_FNT_NORMAL), background_color, COLOR_WHITE);
 }
 
@@ -180,7 +180,7 @@ void general_error(const char *error, const char *module) {
     term_printf(&term, module);
     term_printf(&term, "\n");
 
-    render_term(Rect16(PADDING, 100, 220, 220), &term, GuiDefaults::Font, COLOR_RED_ALERT, COLOR_WHITE);
+    render_term(&term, PADDING, 100, GuiDefaults::Font, COLOR_RED_ALERT, COLOR_WHITE);
 
     static const char rp[] = "RESET PRINTER"; // intentionally not translated yet
     render_text_align(Rect16(PADDING, 260, X_MAX, 30), string_view_utf8::MakeCPUFLASH((const uint8_t *)rp), GuiDefaults::Font,
@@ -680,7 +680,7 @@ void ScreenHardFault(void) {
             term_printf(&term, " ");
     }
 
-    render_term(Rect16(10, 10, 220, 288), &term, resource_font(IDR_FNT_SMALL), COLOR_NAVY, COLOR_WHITE);
+    render_term(&term, 10, 10, resource_font(IDR_FNT_SMALL), COLOR_NAVY, COLOR_WHITE);
     display::DrawText(Rect16(10, 290, 220, 20), string_view_utf8::MakeCPUFLASH((const uint8_t *)project_version_full), resource_font(IDR_FNT_SMALL), COLOR_NAVY, COLOR_WHITE);
 
     while (1) //endless loop

--- a/src/common/circle_buffer.hpp
+++ b/src/common/circle_buffer.hpp
@@ -1,0 +1,87 @@
+// circle_buffer.hpp
+#pragma once
+
+#include <stdint.h>
+
+static constexpr const char *CircleBufferEmpty = "";
+
+// you can never use entire size
+// because write position (end) cannot be equal to begin
+// because begin == end == empty
+template <size_t SIZE, size_t MAX_LENGTH>
+class CircleBuffer {
+    char msg_data[SIZE][MAX_LENGTH];
+    size_t begin; // position of first element
+    size_t end;   // position behind last element == write position
+    size_t pushed;
+    static void incrementIndex(size_t &index) { index = (index + 1) % SIZE; }
+    static void decrementIndex(size_t &index) { index = (index + SIZE - 1) % SIZE; }
+
+public:
+    CircleBuffer()
+        : begin(0)
+        , end(0)
+        , pushed(0) {}
+
+    void push_back(const char *const popup_msg);
+    void push_back_DontRewrite(const char *const popup_msg);
+    size_t Count() const { return (end + SIZE - begin) % SIZE; }
+    bool IsEmpty() const { return begin == end; }
+    size_t PushedCount() const { return pushed; }
+
+    constexpr size_t Size() const { return SIZE; }
+    constexpr size_t MaxStrLen() const { return MAX_LENGTH; }
+
+    const char *ConsumeFirst();   // data must be processed before next push_back
+    const char *ConsumeLast();    // data must be processed before next push_back
+    const char *GetFirst() const; // data must be processed before next push_back
+    const char *GetLast() const;  // data must be processed before next push_back
+};
+
+template <size_t SIZE, size_t MAX_LENGTH>
+void CircleBuffer<SIZE, MAX_LENGTH>::push_back(const char *const popup_msg) {
+    strlcpy(msg_data[end], popup_msg, MAX_LENGTH);
+    incrementIndex(end);
+    if (begin == end) { //begin just was erased, set new begin
+        incrementIndex(begin);
+    }
+    ++pushed;
+}
+
+template <size_t SIZE, size_t MAX_LENGTH>
+void CircleBuffer<SIZE, MAX_LENGTH>::push_back_DontRewrite(const char *const popup_msg) {
+    size_t index = begin;
+    incrementIndex(index);
+    if (index != end)
+        push_back(popup_msg);
+}
+
+template <size_t SIZE, size_t MAX_LENGTH>
+const char *CircleBuffer<SIZE, MAX_LENGTH>::ConsumeFirst() {
+    if (IsEmpty())
+        return CircleBufferEmpty;
+    const char *ret = GetFirst();
+    incrementIndex(begin);
+    return ret;
+}
+
+template <size_t SIZE, size_t MAX_LENGTH>
+const char *CircleBuffer<SIZE, MAX_LENGTH>::ConsumeLast() {
+    if (IsEmpty())
+        return CircleBufferEmpty;
+    const char *ret = GetLast();
+    decrementIndex(end);
+    return ret;
+}
+
+template <size_t SIZE, size_t MAX_LENGTH>
+const char *CircleBuffer<SIZE, MAX_LENGTH>::GetFirst() const {
+    return IsEmpty() ? CircleBufferEmpty : msg_data[begin];
+}
+
+template <size_t SIZE, size_t MAX_LENGTH>
+const char *CircleBuffer<SIZE, MAX_LENGTH>::GetLast() const {
+    size_t index = end;
+    decrementIndex(index);
+    return IsEmpty() ? CircleBufferEmpty : msg_data[index];
+}

--- a/src/common/marlin_client.c
+++ b/src/common/marlin_client.c
@@ -48,6 +48,7 @@ typedef struct _marlin_client_t {
     fsm_create_t fsm_create_cb;   // to register callback for screen creation (M876), callback ensures M876 is processed asap, so there is no need for queue
     fsm_destroy_t fsm_destroy_cb; // to register callback for screen destruction
     fsm_change_t fsm_change_cb;   // to register callback for change of state
+    message_cb_t message_cb;      // to register callback message
 } marlin_client_t;
 
 #pragma pack(pop)
@@ -106,6 +107,8 @@ marlin_vars_t *marlin_client_init(void) {
         client->reheating = 0;
         client->fsm_create_cb = NULL;
         client->fsm_destroy_cb = NULL;
+        client->fsm_change_cb = NULL;
+        client->message_cb = NULL;
         marlin_client_task[client_id] = osThreadGetId();
     }
     osSemaphoreRelease(marlin_server_sema);
@@ -191,6 +194,18 @@ int marlin_client_set_fsm_change_cb(fsm_change_t cb) {
     }
     return 0;
 }
+
+//register callback to message
+//return success
+int marlin_client_set_message_cb(message_cb_t cb) {
+    marlin_client_t *client = _client_ptr();
+    if (client && cb) {
+        client->message_cb = cb;
+        return 1;
+    }
+    return 0;
+}
+
 int marlin_processing(void) {
     marlin_client_t *client = _client_ptr();
     if (client)
@@ -612,17 +627,6 @@ void marlin_park_head(void) {
     _wait_ack_from_server(client->id);
 }
 
-uint8_t marlin_message_received(void) {
-    marlin_client_t *client = _client_ptr();
-    if (client == 0)
-        return 0;
-    if (client->flags & MARLIN_CFLG_MESSAGE) {
-        client->flags &= ~MARLIN_CFLG_MESSAGE;
-        return 1;
-    } else
-        return 0;
-}
-
 // returns 1 if reheating is in progress, otherwise 0
 int marlin_reheating(void) {
     marlin_client_t *client = _client_ptr();
@@ -732,9 +736,6 @@ static void _process_client_message(marlin_client_t *client, variant8_t msg) {
         case MARLIN_EVT_CommandEnd:
             client->command = MARLIN_CMD_NONE;
             break;
-        case MARLIN_EVT_Message:
-            client->flags |= MARLIN_CFLG_MESSAGE;
-            break;
         case MARLIN_EVT_Reheat:
             client->reheating = (uint8_t)variant8_get_ui32(msg);
             break;
@@ -752,6 +753,10 @@ static void _process_client_message(marlin_client_t *client, variant8_t msg) {
         case MARLIN_EVT_FSM_Change:
             if (client->fsm_change_cb)
                 client->fsm_change_cb((uint8_t)variant8_get_ui32(msg), (uint8_t)(variant8_get_ui32(msg) >> 8), (uint8_t)(variant8_get_ui32(msg) >> 16), (uint8_t)(variant8_get_ui32(msg) >> 24));
+            break;
+        case MARLIN_EVT_Message:
+            if (client->message_cb)
+                client->message_cb(msg.pch);
             break;
             //not handled events
             //do not use default, i want all events listed here, so new event will generate warning, when not added

--- a/src/common/marlin_client.h
+++ b/src/common/marlin_client.h
@@ -10,11 +10,12 @@
 static const uint16_t MARLIN_CFLG_STARTED = 0x01; // client started (set in marlin_client_init)
 static const uint16_t MARLIN_CFLG_PROCESS = 0x02; // loop processing in main thread is enabled
 static const uint16_t MARLIN_CFLG_LOWHIGH = 0x08; // receiving low/high part of client message
-static const uint16_t MARLIN_CFLG_MESSAGE = 0x10; // receiving status change message
 
 #ifdef __cplusplus
 extern "C" {
 #endif //__cplusplus
+
+typedef void (*message_cb_t)(const char *);
 
 //-----------------------------------------------------------------------------
 //externs from marlin server todo fixme use variables
@@ -46,6 +47,8 @@ extern int marlin_client_set_fsm_create_cb(fsm_create_t cb);
 extern int marlin_client_set_fsm_destroy_cb(fsm_destroy_t cb);
 //sets dialog callback, returns 1 on success
 extern int marlin_client_set_fsm_change_cb(fsm_change_t cb);
+//sets dialog message, returns 1 on success
+extern int marlin_client_set_message_cb(message_cb_t cb);
 // returns enabled status of loop processing
 extern int marlin_processing(void);
 
@@ -177,8 +180,6 @@ extern void marlin_print_pause(void);
 extern void marlin_print_resume(void);
 
 extern void marlin_park_head(void);
-
-extern uint8_t marlin_message_received(void);
 
 // returns 1 if reheating is in progress, otherwise 0
 extern int marlin_reheating(void);

--- a/src/common/marlin_server.cpp
+++ b/src/common/marlin_server.cpp
@@ -84,6 +84,7 @@ typedef struct _marlin_server_t {
     uint32_t fsmCreate;                              // fsm create ui32 argument for resend
     uint32_t fsmDestroy;                             // fsm destroy ui32 argument for resend
     uint32_t fsmChange;                              // fsm change ui32 argument for resend
+    variant8_t event_messages[MARLIN_MAX_CLIENTS];   // last MARLIN_EVT_Message for clients, cannot use cvariant, desctructor would free memory
 } marlin_server_t;
 
 #pragma pack(pop)
@@ -105,30 +106,14 @@ uint32_t *pCommand = &marlin_server.command;
 #endif
 marlin_server_idle_t *marlin_server_idle_cb = 0; // idle callback
 
-//==========MSG_STACK===================
-//	top of the stack is at [0]
-
-msg_stack_t msg_stack = { '\0', 0 };
-
 void _add_status_msg(const char *const popup_msg) {
-    char message[MSG_MAX_LENGTH];
-    memset(message, '\0', sizeof(message) * sizeof(char)); // set to zeros to be on the safe side
-
-    strlcpy(message, popup_msg, MSG_MAX_LENGTH);
-
-    for (uint8_t i = msg_stack.count; i; i--) {
-        if (i == MSG_STACK_SIZE)
-            i--; // last place of the limited stack will be always overwritten
-
-        memset(msg_stack.msg_data[i], '\0', sizeof(msg_stack.msg_data[i]) * sizeof(char)); // set to zeros to be on the safe side
-        strlcpy(msg_stack.msg_data[i], msg_stack.msg_data[i - 1], sizeof(msg_stack.msg_data[i]));
+    //I could check client mask here
+    for (size_t i = 0; i < MARLIN_MAX_CLIENTS; ++i) {
+        variant8_done(&marlin_server.event_messages[i]);                           //destroy unsent message - free dynamic memory
+        marlin_server.event_messages[i] = variant8_pchar((char *)popup_msg, 0, 1); //variant malloc - detached on send
+        marlin_server.event_messages[i].type = VARIANT8_USER;                      //set user type so client can recognize it as event
+        marlin_server.event_messages[i].usr8 = MARLIN_EVT_Message;
     }
-
-    memset(msg_stack.msg_data[0], '\0', sizeof(msg_stack.msg_data[0]) * sizeof(char)); // set to zeros to be on the safe side
-    strlcpy(msg_stack.msg_data[0], message, sizeof(msg_stack.msg_data[0]));
-
-    if (msg_stack.count < MSG_STACK_SIZE)
-        msg_stack.count++;
 }
 
 //-----------------------------------------------------------------------------
@@ -662,9 +647,14 @@ static int _send_notify_to_client(osMessageQId queue, variant8_t msg) {
 
 // send event notification to client (called from server thread)
 static int _send_notify_event_to_client(int client_id, osMessageQId queue, MARLIN_EVT_t evt_id, uint32_t usr32, uint16_t usr16) {
-    variant8_t msg;
-    msg = variant8_user(usr32, usr16, evt_id);
-    return _send_notify_to_client(queue, msg);
+    variant8_t msg = evt_id == MARLIN_EVT_Message ? marlin_server.event_messages[client_id] : variant8_user(usr32, usr16, evt_id);
+    bool ret = _send_notify_to_client(queue, msg);
+
+    // clear sent client message
+    if (evt_id == MARLIN_EVT_Message && ret) {
+        marlin_server.event_messages[client_id] = variant8_empty();
+    }
+    return ret;
 }
 
 // send event notification to client - multiple events (called from server thread)

--- a/src/common/marlin_server.h
+++ b/src/common/marlin_server.h
@@ -16,30 +16,12 @@ static const uint16_t MARLIN_SFLG_EXCMODE = 0x0010; // exclusive mode enabled (c
 
 // server variable update interval [ms]
 static const uint8_t MARLIN_UPDATE_PERIOD = 100;
-enum {
-    MSG_STACK_SIZE = 8,  //status message stack size
-    MSG_MAX_LENGTH = 21, //status message max length
-};
 
 typedef void(marlin_server_idle_t)(void);
-
-#pragma pack(push)
-#pragma pack(1)
-
-typedef struct msg_stack {
-
-    char msg_data[MSG_STACK_SIZE][MSG_MAX_LENGTH];
-    uint8_t count;
-
-} msg_stack_t;
-
-#pragma pack(pop)
 
 #ifdef __cplusplus
 extern "C" {
 #endif //__cplusplus
-
-extern msg_stack_t msg_stack;
 
 // callback for idle operation inside marlin (called from ExtUI handler onIdle)
 extern marlin_server_idle_t *marlin_server_idle_cb;

--- a/src/common/variant8.cpp
+++ b/src/common/variant8.cpp
@@ -713,7 +713,7 @@ cvariant8 &cvariant8::attach(variant8_t var8) {
 
 variant8_t cvariant8::detach() {
     variant8_t var8 = *this;
-    variant8_done(this);
+    *((variant8_t *)(this)) = variant8_empty();
     return var8;
 }
 #ifdef CLEAN_UNUSED

--- a/src/gui/ScreenHandler.cpp
+++ b/src/gui/ScreenHandler.cpp
@@ -114,7 +114,14 @@ Screens *Screens::Access() {
 void Screens::ScreenEvent(window_t *sender, uint8_t event, void *param) {
     if (current == nullptr)
         return;
+    //todo shouldn't I use "sender ? sender : current.get()"?
     current->ScreenEvent(current.get(), event, param);
+}
+
+void Screens::WindowEvent(uint8_t event, void *param) {
+    if (current == nullptr)
+        return;
+    current->WindowEvent(current.get(), event, param);
 }
 
 void Screens::Draw() {
@@ -194,7 +201,7 @@ void Screens::Loop() {
         current = creator();
         if (!current->IsChildCaptured())
             current->SetCapture();
-        if (!current->IsChildFocused() && !current->IsChildFocused()) {
+        if (!current->IsFocused() && !current->IsChildFocused()) {
             window_t *child = current->GetFirstEnabledSubWin();
             if (child) {
                 child->SetFocus();

--- a/src/gui/ScreenHandler.hpp
+++ b/src/gui/ScreenHandler.hpp
@@ -44,6 +44,7 @@ public:
     void Draw();
 
     void ScreenEvent(window_t *sender, uint8_t event, void *param);
+    void WindowEvent(uint8_t event, void *param);
 
     window_frame_t *Get();
 

--- a/src/gui/dialogs/IDialog.cpp
+++ b/src/gui/dialogs/IDialog.cpp
@@ -10,8 +10,28 @@ IDialog::IDialog(Rect16 rc)
 }
 
 IDialog::~IDialog() {
+    releaseCapture();
+}
+
+bool IDialog::consumeCloseFlag() const {
+    return Screens::Access()->ConsumeClose();
+}
+
+void IDialog::guiLoop() const {
+    gui_loop();
+}
+
+void IDialog::releaseCapture() {
     if (prev_capture)
         prev_capture->SetCapture();
+    clearCapture();
+}
+void IDialog::clearCapture() {
+    prev_capture = nullptr;
+}
+
+void IDialog::StoreCapture() {
+    prev_capture = GetCapturedWindow();
 }
 
 void create_blocking_dialog_from_normal_window(window_t &dlg) {
@@ -23,7 +43,6 @@ void create_blocking_dialog_from_normal_window(window_t &dlg) {
     } else {
         dlg.SetCapture(); //set capture to dlg, events for list are forwarded in window_dlg_preheat_event
     }
-
     //gui_invalidate();
 
     while (!Screens::Access()->ConsumeClose()) {
@@ -33,13 +52,4 @@ void create_blocking_dialog_from_normal_window(window_t &dlg) {
     //if dialog or its child window has capture, it must handle its release itsefl
     if (prev_capture)
         prev_capture->SetCapture();
-}
-
-void IDialog::MakeBlocking(void (*action)()) const {
-    //gui_invalidate();
-
-    while (!Screens::Access()->ConsumeClose()) {
-        gui_loop();
-        action();
-    }
 }

--- a/src/gui/dialogs/window_dlg_popup.cpp
+++ b/src/gui/dialogs/window_dlg_popup.cpp
@@ -7,74 +7,51 @@
 
 #include "window_dlg_popup.hpp"
 #include "display_helper.h"
-#include "gui.hpp"
-#include "dbg.h"
-#include "stm32f4xx_hal.h"
 #include "i18n.h"
 #include "ScreenHandler.hpp"
 
-static const constexpr uint16_t POPUP_DELAY_MS = 1000;
-
-extern msg_stack_t msg_stack;
-
-window_dlg_popup_t::window_dlg_popup_t(window_t *parent, Rect16 rect)
-    : window_t(parent, rect)
-    , color_text(GuiDefaults::ColorText)
-    , font(GuiDefaults::Font)
-    , font_title(GuiDefaults::FontBig)
-    , padding(GuiDefaults::Padding)
-    , timer(0)
-    , text("") {
-    Enable();
+window_dlg_popup_t::window_dlg_popup_t(Rect16 rect, string_view_utf8 txt)
+    : IDialog(rect)
+    , text(this, rect, is_multiline::yes, is_closed_on_click_t::no, txt)
+    , open_time(0)
+    , ttl(0) {
+    text.SetAlignment(ALIGN_LEFT_TOP);
+    text.SetPadding({ 0, 2, 0, 2 });
 }
-/*
-void window_dlg_popup_draw(window_dlg_popup_t *window) {
-    if (window->IsVisible()) {
-        Rect16 rc = window->rect;
-        rc = Rect16::Height_t(140);
 
-        if (window->IsInvalid()) {
-            display::FillRect(rc, window->color_back);
-            Rect16 text_rc = rc;
-            text_rc.x += 10;
-            text_rc.y += 20;
-            text_rc.h = 30;
-            text_rc.w -= 10;
-            render_text_align(text_rc, _(window->text),
-                window->font, window->color_back,
-                window->color_text, window->padding,
-                ALIGN_LEFT_CENTER);
-            window->Validate();
+void window_dlg_popup_t::Show(string_view_utf8 txt, uint32_t time) {
+    static window_dlg_popup_t dlg(Rect16(0, 70, 240, 120), txt);
+    dlg.open_time = HAL_GetTick();
+    dlg.ttl = time;
+    dlg.text.SetText(txt);
+    if (!dlg.GetParent()) {
+        window_t *parent = Screens::Access()->Get();
+        if (parent) {
+            dlg.SetParent(parent);
+            parent->RegisterSubWin(&dlg);
         }
     }
-}*/
-
-void gui_pop_up(void) {
-
-    static uint8_t opened = 0;
-    if (opened == 1)
-        return;
-    opened = 1;
-
-    window_dlg_popup_t dlg(nullptr, Rect16(0, 32, 240, 120));
-
-    window_t *id_capture = window_t::GetCapturedWindow();
-    memset(dlg.text, '\0', sizeof(dlg.text) * sizeof(char)); // set to zeros to be on the safe side
-    strlcpy(dlg.text, msg_stack.msg_data[0], sizeof(dlg.text));
-    gui_invalidate();
-    dlg.SetCapture();
-
-    dlg.timer = HAL_GetTick();
-
-    while ((HAL_GetTick() - dlg.timer) < POPUP_DELAY_MS) {
-        gui_loop();
+    if (GetCapturedWindow() != &dlg) {
+        dlg.StoreCapture();
+        dlg.SetCapture();
     }
+    //in 1st call text will be set twice, I could use static bool variable to prevent it
+    //but i prefer fewer code instead
+}
 
-    //window_destroy(id);
-    if (id_capture)
-        id_capture->SetCapture();
-    window_t *pWin = Screens::Access()->Get();
-    if (pWin != 0)
-        pWin->Invalidate();
-    opened = 0;
+//no need to care about focus/caption after unregistration
+//Screens::Loop() auto sets focus and caption to new screen or its child window
+void window_dlg_popup_t::UnregisterFromParent() {
+    if (!GetParent())
+        return;
+    GetParent()->UnregisterSubWin(this);
+    SetParent(nullptr);
+    releaseCapture();
+}
+
+void window_dlg_popup_t::windowEvent(window_t *sender, uint8_t event, void *param) {
+    const uint32_t openned = HAL_GetTick() - open_time;
+    if (event == WINDOW_EVENT_LOOP && openned > ttl) //todo use timer
+        UnregisterFromParent();
+    IDialog::windowEvent(sender, event, param);
 }

--- a/src/gui/dialogs/window_dlg_popup.hpp
+++ b/src/gui/dialogs/window_dlg_popup.hpp
@@ -7,18 +7,24 @@
 
 #pragma once
 
-#include "window.hpp"
-#include "marlin_server.h"
+#include "IDialog.hpp"
+#include "window_text.hpp"
 
-struct window_dlg_popup_t : public window_t {
-    color_t color_text;
-    font_t *font;
-    font_t *font_title;
-    padding_ui8_t padding;
-    uint32_t timer;
-    // uint16_t flags;
-    char text[MSG_MAX_LENGTH];
-    window_dlg_popup_t(window_t *parent, Rect16 rect);
+//Singleton dialog for messages
+class window_dlg_popup_t : public IDialog {
+    window_text_t text;
+    uint32_t open_time;
+    uint32_t ttl; //time to live
+
+    window_dlg_popup_t(Rect16 rect, string_view_utf8 txt);
+    window_dlg_popup_t(const window_dlg_popup_t &) = delete;
+
+    void UnregisterFromParent();
+
+protected:
+    virtual void windowEvent(window_t *sender, uint8_t event, void *param) override;
+
+public:
+    //register dialog to actual screen
+    static void Show(string_view_utf8 txt, uint32_t time = 1000);
 };
-
-extern void gui_pop_up(void);

--- a/src/gui/dialogs/window_dlg_wait.cpp
+++ b/src/gui/dialogs/window_dlg_wait.cpp
@@ -19,7 +19,7 @@ window_dlg_wait_t::window_dlg_wait_t(Rect16 rect)
     text.SetAlignment(ALIGN_CENTER);
 }
 
-void gui_dlg_wait(void (*closing_callback)()) {
+void gui_dlg_wait(std::function<void()> closing_callback) {
 
     window_dlg_wait_t dlg(GuiDefaults::RectScreenBody);
     dlg.MakeBlocking(closing_callback);

--- a/src/gui/dialogs/window_dlg_wait.hpp
+++ b/src/gui/dialogs/window_dlg_wait.hpp
@@ -32,4 +32,4 @@ static const constexpr uint8_t DLG_W8_DRAW_PROGRESS = 0x02;  // Draw progress ba
 *
 * It creates inner gui_loop cycle that keeps GUI running while waiting.
 */
-void gui_dlg_wait(void (*closing_callback)());
+void gui_dlg_wait(std::function<void()> closing_callback);

--- a/src/gui/guimain.cpp
+++ b/src/gui/guimain.cpp
@@ -13,13 +13,11 @@
 #include "window_header.hpp"
 #include "window_temp_graph.hpp"
 #include "window_dlg_wait.hpp"
-#ifdef _DEBUG
-    #include "window_dlg_popup.hpp"
-#endif //_DEBUG
+#include "window_dlg_popup.hpp"
 #include "window_dlg_preheat.hpp"
 #include "screen_print_preview.hpp"
 #include "screen_watchdog.hpp"
-
+#include "IScreenPrinting.hpp"
 #include "DialogHandler.hpp"
 #include "sound.hpp"
 #include "i18n.h"
@@ -59,9 +57,22 @@ char gui_media_LFN[FILE_NAME_MAX_LEN + 1];
 char gui_media_SFN_path[FILE_PATH_MAX_LEN + 1];
 
 #ifdef GUI_JOGWHEEL_SUPPORT
-
 Jogwheel jogwheel(JOGWHEEL_PIN_EN1, JOGWHEEL_PIN_EN2, JOGWHEEL_PIN_ENC);
 #endif // GUI_JOGWHEEL_SUPPORT
+
+MsgBuff_t &MsgCircleBuffer() {
+    static CircleBuffer<MSG_STACK_SIZE, MSG_MAX_LENGTH> ret;
+    return ret;
+}
+
+void MsgCircleBuffer_cb(const char *txt) {
+    MsgCircleBuffer().push_back(txt);
+    //cannot open == already openned
+    if (!IScreenPrinting::CanOpen()) {
+        window_dlg_popup_t::Show(string_view_utf8::MakeRAM((const uint8_t *)txt));
+    }
+}
+
 extern "C" void gui_run(void) {
     if (diag_fastboot)
         return;
@@ -99,6 +110,7 @@ extern "C" void gui_run(void) {
     marlin_client_set_fsm_create_cb(DialogHandler::Open);
     marlin_client_set_fsm_destroy_cb(DialogHandler::Close);
     marlin_client_set_fsm_change_cb(DialogHandler::Change);
+    marlin_client_set_message_cb(MsgCircleBuffer_cb);
 
     Sound_Play(eSOUND_TYPE_Start);
 
@@ -123,13 +135,7 @@ extern "C" void gui_run(void) {
             MsgBoxInfo(_("Heating disabled due to 30 minutes of inactivity."), Responses_Ok);
         }
         gui_loop();
-        /*if (marlin_message_received()) {
-            screen_t *curr = screen_get_curr();
-            if (curr == get_scr_printing()) {
-                screen_dispatch_event(NULL, WINDOW_EVENT_MESSAGE, 0);
-            }
-        }
-        if (menu_timeout_enabled) {
+        /*if (menu_timeout_enabled) {
             gui_timeout_id = gui_get_menu_timeout_id();
             if (gui_timer_expired(gui_timeout_id) == 1) {
                 screen_close_multiple(scrn_close_on_timeout);

--- a/src/gui/screen_mesh_bed_lv.hpp
+++ b/src/gui/screen_mesh_bed_lv.hpp
@@ -26,8 +26,7 @@ struct screen_mesh_bed_lv_data_t : public window_frame_t {
     window_text_button_t btMesh;
     window_text_t text_mesh_state;
     window_term_t term;
-    term_t terminal;
-    uint8_t term_buff[TERM_BUFF_SIZE(20, 16)]; //chars and attrs (640 bytes) + change bitmask (40 bytes)
+    term_buff_t<20, 16> term_buff;
     window_text_button_t textExit;
     static mesh_state_t mesh_state;
 

--- a/src/gui/screen_messages.cpp
+++ b/src/gui/screen_messages.cpp
@@ -11,60 +11,25 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include "i18n.h"
-
-void _window_list_add_message_item(window_list_t * /*pwindow_list*/, uint16_t index,
-    const char **pptext, uint16_t *msg_icon) {
-    static const char empty_str[] = "";
-    static const char back_str[] = N_("BACK");
-    if (index == 0) {
-        *pptext = back_str;
-        //*pid_icon = IDR_PNG_filescreen_icon_up_folder;
-    } else {
-        if (index <= msg_stack.count)
-            *pptext = msg_stack.msg_data[index - 1];
-        else
-            *pptext = empty_str; // it shouldn't ever get here (safety measure)
-    }
-    *msg_icon = 0;
-}
-
-void _msg_stack_del(uint8_t del_index) { // del_index = < 0 ; MSG_STACK_SIZE - 1 >
-
-    // when we delete from last spot of the limited stack [MSG_STACK_SIZE - 1], no swapping is needed, for cycle won't start
-    for (uint8_t i = del_index; i + 1 < msg_stack.count; i++) {
-        memset(msg_stack.msg_data[i], '\0', sizeof(msg_stack.msg_data[i]) * sizeof(char)); // set to zeros to be on the safe side
-        strlcpy(msg_stack.msg_data[i], msg_stack.msg_data[i + 1], sizeof(msg_stack.msg_data[i]));
-    }
-    msg_stack.count--;
-}
+#include "gui.hpp"
 
 screen_messages_data_t::screen_messages_data_t()
     : window_frame_t()
     , header(this)
     , footer(this)
-    , list(this, GuiDefaults::RectScreenBody) {
-    Disable();
+    , term(this, GuiDefaults::RectScreenBody.TopLeft(), &term_buff) { // Rect16(10, 28, 11 * 20, 18 * 16))
     header.SetText(_("MESSAGES"));
-
-    list.SetItemCount(msg_stack.count + 1);
-    list.SetItemIndex(0);
-    list.SetCallback(_window_list_add_message_item);
-
-    list.SetCapture();
 }
 
 void screen_messages_data_t::windowEvent(window_t *sender, uint8_t event, void *param) {
-
-    switch (event) {
-    case WINDOW_EVENT_CLICK:
-        if (list.index == 0) {
-            Screens::Access()->Close();
-            return;
-        }
-        break;
-    default:
-        break;
+    if (event == WINDOW_EVENT_CLICK) {
+        Screens::Access()->Close();
+    } else {
+        window_frame_t::windowEvent(sender, event, param);
     }
 
-    list.count = msg_stack.count + 1;
+    //must be last window_frame_t could validate term
+    while (!MsgCircleBuffer().IsEmpty()) {
+        term.Printf("%s\n", MsgCircleBuffer().ConsumeFirst());
+    }
 }

--- a/src/gui/screen_messages.hpp
+++ b/src/gui/screen_messages.hpp
@@ -3,11 +3,13 @@
 #include "gui.hpp"
 #include "window_header.hpp"
 #include "status_footer.h"
+#include "window_term.hpp"
 
 struct screen_messages_data_t : public window_frame_t {
     window_header_t header;
     status_footer_t footer;
-    window_list_t list;
+    window_term_t term;
+    term_buff_t<20, 13> term_buff;
 
 public:
     screen_messages_data_t();

--- a/src/gui/screen_printing.cpp
+++ b/src/gui/screen_printing.cpp
@@ -12,6 +12,7 @@
 #include "wui_api.h"
 #include "i18n.h"
 #include "../lang/format_print_will_end.hpp"
+#include "window_dlg_popup.hpp"
 
 #ifdef DEBUG_FSENSOR_IN_HEADER
     #include "filament_sensor.h"
@@ -124,13 +125,9 @@ screen_printing_data_t::screen_printing_data_t()
     , w_time_value(this, Rect16(10, 148, 101, 20), is_multiline::no)
     , w_etime_label(this, Rect16(130, 128, 101, 20), is_multiline::no)
     , w_etime_value(this, Rect16(30, 148, 201, 20), is_multiline::no)
-
     , last_print_duration(-1)
     , last_time_to_end(-1)
-
-    , w_message(this, Rect16(10, 75, 230, 95), is_multiline::yes)
     , message_timer(0)
-    , message_flag(false)
     , stop_pressed(false)
     , waiting_for_abort(false)
     , state__readonly__use_change_print_state(printing_state_t::COUNT)
@@ -171,41 +168,6 @@ screen_printing_data_t::screen_printing_data_t()
     w_time_value.SetPadding({ 0, 2, 0, 2 });
     // this MakeRAM is safe - text_time_dur is allocated in RAM for the lifetime of pw
     w_time_value.SetText(string_view_utf8::MakeRAM((const uint8_t *)text_time_dur.data()));
-
-    w_message.font = resource_font(IDR_FNT_NORMAL);
-    w_message.SetAlignment(ALIGN_LEFT_TOP);
-    w_message.SetPadding({ 0, 2, 0, 2 });
-    w_message.SetText(_("No messages"));
-    w_message.Hide();
-    message_flag = false;
-}
-
-void screen_printing_data_t::open_popup_message() {
-    w_etime_label.Hide();
-    w_etime_value.Hide();
-    w_progress.Hide();
-    w_time_label.Hide();
-    w_time_value.Hide();
-
-    // this MakeRAM is safe - msg stack and its items are allocated in RAM for the lifetime of pw
-    w_message.SetText(string_view_utf8::MakeRAM((const uint8_t *)msg_stack.msg_data[0]));
-
-    w_message.Show();
-    message_timer = HAL_GetTick();
-    message_flag = true;
-}
-
-void screen_printing_data_t::close_popup_message() {
-    w_etime_label.Show();
-    w_etime_value.Show();
-    w_progress.Show();
-    w_time_label.Show();
-    w_time_value.Show();
-
-    w_message.SetText(string_view_utf8::MakeNULLSTR());
-
-    w_message.Hide();
-    message_flag = false;
 }
 
 #ifdef DEBUG_FSENSOR_IN_HEADER
@@ -238,15 +200,6 @@ void screen_printing_data_t::windowEvent(window_t *sender, uint8_t event, void *
         marlin_print_abort();
         waiting_for_abort = false;
         return;
-    }
-
-    if (event == WINDOW_EVENT_MESSAGE && msg_stack.count > 0) {
-        open_popup_message();
-        return;
-    }
-
-    if ((!is_abort_state(marlin_vars()->print_state)) && message_flag && (HAL_GetTick() - message_timer >= POPUP_MSG_DUR_MS)) {
-        close_popup_message();
     }
 
     if (p_state == printing_state_t::PRINTED && marlin_error(MARLIN_ERR_ProbingFailed)) {

--- a/src/gui/screen_printing.hpp
+++ b/src/gui/screen_printing.hpp
@@ -61,10 +61,7 @@ class screen_printing_data_t : public IScreenPrinting {
     //std::array<char, 15> label_etime;  // "Remaining Time" or "Print will end" // nope, if you have only 2 static const strings, you can swap pointers
     string_view_utf8 label_etime;      // not sure if we really must keep this in memory
     std::array<char, 5> text_filament; // 999m\0 | 1.2m\0
-
-    window_text_t w_message; //Messages from onStatusChanged()
     uint32_t message_timer;
-    bool message_flag;
     bool stop_pressed;
     bool waiting_for_abort; /// flag specific for stop pressed when MBL is performed
     printing_state_t state__readonly__use_change_print_state;
@@ -76,8 +73,6 @@ public:
 private:
     virtual void windowEvent(window_t *sender, uint8_t event, void *param) override;
     void invalidate_print_state();
-    void open_popup_message();
-    void close_popup_message();
     void disable_tune_button();
     void enable_tune_button();
     void update_progress(uint8_t percent, uint16_t print_speed);

--- a/src/gui/screen_test_term.hpp
+++ b/src/gui/screen_test_term.hpp
@@ -12,8 +12,8 @@
 struct screen_test_term_data_t : public window_frame_t {
     window_text_t text;
     window_term_t term;
-    term_t terminal;
-    uint8_t term_buff[TERM_BUFF_SIZE(20, 16)]; //chars and attrs (640 bytes) + change bitmask (40 bytes)
+    term_buff_t<20, 16> term_buff;
+
 public:
     screen_test_term_data_t();
 

--- a/src/gui/test/screen_mesh_bed_lv.cpp
+++ b/src/gui/test/screen_mesh_bed_lv.cpp
@@ -49,18 +49,13 @@ screen_mesh_bed_lv_data_t::screen_mesh_bed_lv_data_t()
     , textMenuName(this, Rect16(0, 0, display::GetW(), row_h), is_multiline::no)
     , btMesh(this, Rect16(2, 50, 200, row_h), []() { if (mesh_state == mesh_state_t::idle) mesh_state = mesh_state_t::start; })
     , text_mesh_state(this, Rect16(2, 75, 200, row_h), is_multiline::no)
-    , term(this, Rect16(10, 28, 11 * 20, 18 * 16))
-    //, terminal(this, )
+    , term(this, { 10, 28 }, &term_buff)
     , textExit(this, Rect16(2, 245, 60, 22), []() {if (mesh_state != mesh_state_t::idle) return; Screens::Access()->Close(); }) {
 
     textMenuName.font = resource_font(IDR_FNT_BIG);
     textMenuName.SetText(_("MESH BED L."));
 
     btMesh.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)btnMeshStrings[0]));
-
-    //terminal
-    term_init(&(terminal), 20, 16, term_buff);
-    term.term = &(terminal);
 
     //exit and footer
     textExit.font = resource_font(IDR_FNT_BIG);

--- a/src/gui/test/screen_test_term.cpp
+++ b/src/gui/test/screen_test_term.cpp
@@ -10,14 +10,11 @@
 screen_test_term_data_t::screen_test_term_data_t()
     : window_frame_t()
     , text(this, Rect16(10, 0, 220, 22), is_multiline::no)
-    , term(this, Rect16(10, 28, 11 * 20, 18 * 16)) {
+    , term(this, { 10, 28 }, &term_buff) {
     SetBackColor(COLOR_GRAY);
 
     static const char tst[] = "Test";
     text.SetText(string_view_utf8::MakeCPUFLASH((const uint8_t *)tst));
-
-    term_init(&(terminal), 20, 16, term_buff);
-    term.term = &(terminal);
 }
 
 void screen_test_term_data_t::windowEvent(window_t *sender, uint8_t event, void *param) {
@@ -26,10 +23,7 @@ void screen_test_term_data_t::windowEvent(window_t *sender, uint8_t event, void 
         Screens::Access()->Close();
     }
     if (event != WINDOW_EVENT_LOOP) {
-        term_printf(term.term, "%010d w:%d e:%d\n", HAL_GetTick(), winid, (int)event);
-        //	else
-        //		if (term.term->flg & TERM_FLG_CHANGED)
-        term.Invalidate();
+        term.Printf("%010d w:%d e:%d\n", HAL_GetTick(), winid, (int)event);
     } else {
         window_frame_t::windowEvent(sender, event, param);
     }

--- a/src/guiapi/include/gui.hpp
+++ b/src/guiapi/include/gui.hpp
@@ -40,11 +40,20 @@ extern osThreadId gui_task_handle;
     #include "window_msgbox.hpp"
     #include "window_progress.hpp"
     #include "window_qr.hpp"
+    #include "circle_buffer.hpp"
 
 extern uint8_t gui_get_nesting(void);
 
 extern void gui_loop(void);
 
 extern void gui_reset_menu_timer();
+
+//meant to be use as MsgCircleBuffer().push_back(txt);
+static constexpr size_t MSG_STACK_SIZE = 8 + 1; //status message stack size
+static constexpr size_t MSG_MAX_LENGTH = 21;    //status message max length
+using MsgBuff_t = CircleBuffer<MSG_STACK_SIZE, MSG_MAX_LENGTH>;
+
+MsgBuff_t &MsgCircleBuffer();
+void MsgCircleBuffer_cb(const char *txt);
 
 #endif //GUI_WINDOW_SUPPORT

--- a/src/guiapi/include/window_term.hpp
+++ b/src/guiapi/include/window_term.hpp
@@ -4,18 +4,44 @@
 #include "window.hpp"
 #include "term.h"
 
+//each character is folowed by its flags
+//at the end of array is stored bit array of change bits
+template <size_t COL, size_t ROW>
+struct term_buff_t {
+    static constexpr size_t size() {
+        return ((ROW * COL * 2) + (ROW * COL + 7) / 8);
+    }
+    static constexpr size_t Columns() { return COL; }
+    static constexpr size_t Rows() { return ROW; }
+
+    uint8_t buff[size()];
+};
+
 //todo, why is this using 2nd class term_t?
 //to be sizeable?
 class window_term_t : public window_t {
 public:
     color_t color_text;
     font_t *font;
-    term_t *term;
+    term_t term;
 
-    window_term_t(window_t *parent, Rect16 rect);
+    //font must be known in ctor, used to calculate rectangle, do not change it later
+    template <size_t COL, size_t ROW>
+    window_term_t(window_t *parent, point_i16_t pt, term_buff_t<COL, ROW> *term_buff)
+        : window_term_t(parent, pt, term_buff->buff, COL, ROW) {}
+    template <size_t COL, size_t ROW>
+    window_term_t(window_t *parent, point_i16_t pt, term_buff_t<COL, ROW> *term_buff, font_t *fnt)
+        : window_term_t(parent, pt, term_buff->buff, COL, ROW, fnt) {}
+
+    int Printf(const char *fmt, ...);
+    void WriteChar(uint8_t ch);
 
 protected:
     virtual void unconditionalDraw() override;
+
+    //protected ctors - unsafe. To be used by public template ctors
+    window_term_t(window_t *parent, point_i16_t pt, uint8_t *buff, size_t cols, size_t rows);
+    window_term_t(window_t *parent, point_i16_t pt, uint8_t *buff, size_t cols, size_t rows, font_t *fnt);
 };
 
-void render_term(Rect16 rc, term_t *pt, const font_t *font, color_t clr0, color_t clr1);
+void render_term(term_t *pterm, size_t x, size_t y, const font_t *font, color_t color_back, color_t color_text);

--- a/src/guiapi/src/term.cpp
+++ b/src/guiapi/src/term.cpp
@@ -1,4 +1,4 @@
-// term.c
+// term.cpp
 #include <stdarg.h>
 #include <algorithm>
 
@@ -178,7 +178,8 @@ void term_write_char(term_t *pt, uint8_t ch) {
         ++(pt->col);
     }
 }
-
+//duplicit function, todo erase
+//to be replaced by window_term_t::Printf, but it does not work in bsod
 int term_printf(term_t *pt, const char *fmt, ...) {
     va_list va;
     va_start(va, fmt);
@@ -195,3 +196,30 @@ int term_printf(term_t *pt, const char *fmt, ...) {
 
     return ret;
 }
+
+// cannot use this
+// passing va_list into multiple nested functions does not work
+// undefined behavior
+/*
+int term_printf(term_t *pt, const char *fmt, ...) {
+    va_list va;
+    va_start(va, fmt);
+    int ret = term_vprintf(pt, fmt, va);
+    va_end(va);
+    return ret;
+}
+
+
+int term_vprintf(term_t *pt, const char *fmt, va_list va) {
+
+    char text[TERM_PRINTF_MAX];
+
+    int ret = vsnprintf(text, sizeof(text), fmt, va);
+
+    const size_t range = std::min(ret, TERM_PRINTF_MAX);
+    for (size_t i = 0; i < range; i++)
+        term_write_char(pt, text[i]);
+
+    return ret;
+}
+*/

--- a/src/guiapi/src/window.cpp
+++ b/src/guiapi/src/window.cpp
@@ -47,6 +47,8 @@ void window_t::Disable() { flag_enabled = false; }
 void window_t::SetFocus() {
     if (!IsVisible() || !flag_enabled)
         return;
+    if (focused_ptr == this)
+        return;
 
     if (focused_ptr) {
         focused_ptr->Invalidate();

--- a/src/guiapi/src/window_term.cpp
+++ b/src/guiapi/src/window_term.cpp
@@ -1,25 +1,63 @@
-// window_term.c
+// window_term.cpp
 #include "window_term.hpp"
 #include "gui.hpp"
+#include <stdarg.h> //va_list
 
-void render_term(Rect16 rc, term_t *pt, const font_t *font, color_t clr0, color_t clr1) {
+window_term_t::window_term_t(window_t *parent, point_i16_t pt, uint8_t *buff, size_t cols, size_t rows)
+    : window_term_t(parent, pt, buff, cols, rows, GuiDefaults::Font) {
+}
+
+window_term_t::window_term_t(window_t *parent, point_i16_t pt, uint8_t *buff, size_t cols, size_t rows, font_t *fnt)
+    : window_t(parent, Rect16(pt, fnt->w * cols, fnt->h * rows))
+    , color_text(GuiDefaults::ColorText)
+    , font(fnt) {
+    term_init(&term, cols, rows, buff);
+}
+
+void window_term_t::unconditionalDraw() {
+    if (term.flg & TERM_FLG_CHANGED) {
+        render_term(&term, rect.Left(), rect.Top(), font, color_back, color_text);
+    } else
+        display::FillRect(rect, color_back);
+}
+
+int window_term_t::Printf(const char *fmt, ...) {
+    char text[TERM_PRINTF_MAX];
+
+    va_list va;
+    va_start(va, fmt);
+    int ret = vsnprintf(text, sizeof(text), fmt, va);
+    va_end(va);
+
+    const size_t range = std::min(ret, TERM_PRINTF_MAX);
+    for (size_t i = 0; i < range; i++)
+        term_write_char(&term, text[i]);
+
+    Invalidate();
+    return ret;
+}
+
+void window_term_t::WriteChar(uint8_t ch) {
+    term_write_char(&term, ch);
+    Invalidate();
+}
+
+void render_term(term_t *pterm, size_t x, size_t y, const font_t *font, color_t color_back, color_t color_text) {
     uint8_t char_w = font->w;
     uint8_t char_h = font->h;
-    if (pt && (pt->flg & TERM_FLG_CHANGED)) {
-        const uint8_t cols = pt->cols;
-        const uint8_t rows = pt->rows;
-        uint8_t *pb = pt->buff;
-        uint8_t *pm = pt->buff + (cols * rows * 2);
+    if (pterm->flg & TERM_FLG_CHANGED) {
+        uint8_t *pb = pterm->buff;
+        uint8_t *pm = pterm->buff + (pterm->cols * pterm->rows * 2);
         uint8_t msk = 0x01;
         uint8_t c;
         int i = 0;
-        for (uint8_t r = 0; r < rows; ++r)
-            for (c = 0; c < cols; ++c) {
+        for (uint8_t r = 0; r < pterm->rows; ++r)
+            for (c = 0; c < pterm->cols; ++c) {
                 if ((*pm) & msk) {
                     //character is followed by attribute
                     uint8_t ch = *(pb++);
                     pb++; //uint8_t attr = *(pb++);
-                    display::DrawChar(point_ui16(rc.Left() + c * char_w, rc.Top() + r * char_h), ch, font, clr0, clr1);
+                    display::DrawChar(point_ui16(x + c * char_w, y + r * char_h), ch, font, color_back, color_text);
                 } else
                     pb += 2;
                 i++;
@@ -30,17 +68,5 @@ void render_term(Rect16 rc, term_t *pt, const font_t *font, color_t clr0, color_
                     msk = 0x01;
                 }
             }
-    } else
-        display::FillRect(rc, clr0);
-}
-
-void window_term_t::unconditionalDraw() {
-    render_term(rect, term, font, color_back, color_text);
-}
-
-window_term_t::window_term_t(window_t *parent, Rect16 rect)
-    : window_t(parent, rect)
-    , color_text(GuiDefaults::ColorText)
-    , font(GuiDefaults::Font)
-    , term(0) {
+    }
 }


### PR DESCRIPTION
* fix variant detach

* pass event messages with variant8 and create circle message buffer to GUI

* add ability to fire window event into screen handler

* define message callback in marlin api

* make poupup dialog singleton

* use terminal and circle message buffer in screen messages

* bind window term ctor with terminal data structure and use it in all screens but bsod

* rewrite render_term, fix font in window_term ctor (was causing invalid rectangle)